### PR TITLE
fix: accepting only maxConnections > 0

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -19,16 +19,17 @@ export class Client<T> {
 
 	constructor(config: ClientConfig, poolService = ClientPool) {
 		this.config = config;
-		if (config.maxConnections === 0) {
-			this.grpcInstance = this.createClient(config);
-		} else {
-			this.grpcInstance = poolService.create<T>(
-				config.url,
-				config.maxConnections,
-				config,
-				() => this.createClient(config),
+		if (!config.maxConnections && config.maxConnections === 0) {
+			throw new Error(
+				'You need to specify maxConnections greater than 0 so we can set a pool properly!',
 			);
 		}
+		this.grpcInstance = poolService.create<T>(
+			config.url,
+			config.maxConnections,
+			config,
+			() => this.createClient(config),
+		);
 	}
 
 	public getInstance(): T {

--- a/test/unit/client.spec.ts
+++ b/test/unit/client.spec.ts
@@ -103,40 +103,22 @@ describe('client.ts', () => {
 		expect(pool[2].Check).toHaveCallsLike([{ service: '3' }]);
 	});
 
-	it('should Create a Client and exec a call without pool', async () => {
-		jest
-			.spyOn(Client.prototype, 'createClient' as any)
-			.mockImplementation(() => {
-				return {
-					Check: jest.fn(),
-				};
-			});
-		const client = new Client<Health>({
-			namespace: 'abc.def',
-			protoFile: 'health-check.proto',
-			url: 'test.service2',
-			maxConnections: 0,
-			service: 'Health',
-			secure: true,
-		});
-
-		const chosenInstance = client.getInstance();
-		const pool = ClientPool['clientsPools'].get('test.service2')?.connections;
-
+	it('should throw an error when maxConnections are empty', async () => {
+		let error: any;
 		try {
-			await chosenInstance.Check({ service: '1' });
-			await chosenInstance.Check({ service: '2' });
-			await chosenInstance.Check({ service: '3' });
+			new Client<Health>({
+				namespace: 'abc.def',
+				protoFile: 'health-check.proto',
+				url: 'test.service2',
+				maxConnections: 0,
+				service: 'Health',
+				secure: true,
+			});
 		} catch (err) {
-			console.error(err);
+			error = err;
 		}
 
-		expect(pool).toBeUndefined;
-		expect(chosenInstance.Check).toHaveCallsLike(
-			[{ service: '1' }],
-			[{ service: '2' }],
-			[{ service: '3' }],
-		);
+		expect(error).toBeInstanceOf(Error);
 	});
 
 	it('should renew connection on stream error', (done) => {


### PR DESCRIPTION
The package @grpc/grpc-js different from grpc, doesn't work properly with transient instances, it has a memory leak when it is used like that, so, it's important to avoid using maxConnections = 0.

In that way, this PR makes it forbidden