### PR TITLE
feat: adding gRPC middleware support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
   overrides: [{
     files: ['test/*.ts', 'test/**/*.ts'],
     rules: {
-      'no-magic-numbers': 'off',
+      '@typescript-eslint/no-magic-numbers': 'off',
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
     },
@@ -76,10 +76,11 @@ module.exports = {
     'no-fallthrough': 'error',
     'no-invalid-regexp': 'error',
     'no-invalid-this': 'off',
-    'no-magic-numbers': [
+    'no-magic-numbers': 'off',
+    '@typescript-eslint/no-magic-numbers': [
       'error',
       {
-        ignore: [0, 1, -1],
+        ignore: [0, 1, 2, -1],
       },
     ],
     'no-multiple-empty-lines': [
@@ -102,6 +103,9 @@ module.exports = {
     'no-var': 'error',
     'object-shorthand': 'error',
     'one-var': ['error', 'never'],
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-return-await": "off",
+    "@typescript-eslint/return-await": "error",
     '@typescript-eslint/no-unused-vars': 'off',
 		'unused-imports/no-unused-imports-ts': 'error',
 		'unused-imports/no-unused-vars-ts': [

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -1,7 +1,8 @@
 import { ChannelOptions } from '@grpc/grpc-js';
 import { Options as PackageOptions } from '@grpc/proto-loader';
+import { GrpcMiddlewares, GrpcServiceDefinition } from './types';
 
-export interface ClientConfig {
+export interface ClientConfig<TService extends GrpcServiceDefinition = any> {
 	url: string;
 	protoFile: string;
 	namespace: string;
@@ -10,4 +11,5 @@ export interface ClientConfig {
 	maxConnections: number;
 	PackageOptions?: PackageOptions;
 	grpcOptions?: Partial<ChannelOptions>;
+	middlewares?: GrpcMiddlewares<TService>;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,3 +1,4 @@
+import { GrpcServiceClient, GrpcServiceDefinition } from './types';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
 	GrpcObject,
@@ -11,13 +12,13 @@ import { ClientConfig } from './client-config';
 import { ClientPool } from './client-pool';
 import { overloadServices } from './utils/overload-services';
 
-export class Client<T> {
+export class Client<T extends GrpcServiceDefinition<keyof T>> {
 	private packageDefinition!: GrpcObject;
 	private grpcInstance: T;
-	readonly config: ClientConfig;
+	readonly config: ClientConfig<T>;
 	public poolPosition?: number;
 
-	constructor(config: ClientConfig, poolService = ClientPool) {
+	constructor(config: ClientConfig<T>, poolService = ClientPool) {
 		this.config = config;
 		if (config.maxConnections === 0) {
 			this.grpcInstance = this.createClient(config);
@@ -51,7 +52,11 @@ export class Client<T> {
 				return current;
 			}, grpcPackage)[config.service] as ServiceClientConstructor;
 
-		const client = new grpcDef(config.url, credentials, config.grpcOptions);
+		const client = new grpcDef(
+			config.url,
+			credentials,
+			config.grpcOptions,
+		) as GrpcServiceClient;
 		const grpcClient = overloadServices(client, config) as unknown as T;
 		return grpcClient as unknown as T;
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
-export { Client } from './client';
-export { ClientPool } from './client-pool';
-export { ClientConfig } from './client-config';
+export * from './client';
+export * from './client-config';
+export * from './client-pool';
+export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,99 @@
+import {
+	CallOptions,
+	Metadata,
+	ClientDuplexStream,
+	ClientReadableStream,
+	ClientWritableStream,
+	Client,
+} from '@grpc/grpc-js';
+
+export interface RawUnaryCall<P, R> {
+	(param: P, callback: (err: Error, response: R) => void): void;
+	(
+		param: P,
+		deadline: Partial<CallOptions> | undefined,
+		callback: (err: Error, response: R) => void,
+	): void;
+	(
+		param: P,
+		metadata: Metadata,
+		callback: (err: Error, response: R) => void,
+	): void;
+	(
+		param: P,
+		metadata: Metadata,
+		deadline: Partial<CallOptions> | undefined,
+		callback: (err: Error, response: R) => void,
+	): void;
+}
+
+export interface StreamCall<P, R> {
+	(param: P, deadline?: Partial<CallOptions> | undefined): ClientDuplexStream<
+		P,
+		R
+	>;
+	(
+		param: P,
+		metadata: Metadata,
+		deadline?: Partial<CallOptions> | undefined,
+	): ClientDuplexStream<P, R>;
+	requestStream: ClientWritableStream<P>;
+	responseStream: ClientReadableStream<R>;
+}
+
+export interface UnaryCall<P, R> {
+	(param: P, deadline?: Partial<CallOptions> | undefined): PromiseLike<R>;
+	(
+		param: P,
+		metadata: Metadata,
+		deadline?: Partial<CallOptions> | undefined,
+	): PromiseLike<R>;
+}
+
+export type GrpcFunction<P, R> = StreamCall<P, R> | UnaryCall<P, R>;
+
+export function isStreamCall<P, R>(
+	action: GrpcFunction<P, R>,
+): action is StreamCall<P, R> {
+	return (action as StreamCall<P, R>).requestStream ||
+		(action as StreamCall<P, R>).responseStream
+		? true
+		: false;
+}
+
+type KeyType = string | number | symbol;
+
+export type GrpcServiceDefinition<
+	Methods extends KeyType = keyof GrpcServiceDefinition<KeyType>,
+> = Record<Methods, GrpcFunction<any, any>>;
+export type GrpcServiceClient<Methods extends KeyType = KeyType> = Client &
+	GrpcServiceDefinition<Methods>;
+
+export interface FullGrpcParams<
+	TService extends GrpcServiceDefinition<KeyType>,
+	k extends keyof TService,
+> {
+	(
+		param: Parameters<TService[k]>[0],
+		metadata: Metadata,
+		options: Partial<CallOptions>,
+	): void;
+}
+
+export interface OtherGrpcParams {
+	(metadata: Metadata, options: Partial<CallOptions>): void;
+}
+
+export type DefaultGrpcMiddleware = (
+	params: Parameters<OtherGrpcParams>,
+) => void;
+export type GrpcMethodMiddleware<
+	TService extends GrpcServiceDefinition<KeyType>,
+	k extends keyof TService,
+> = (params: Parameters<FullGrpcParams<TService, k>>) => void;
+
+export type GrpcMiddlewares<TService extends GrpcServiceDefinition<KeyType>> = {
+	[k in keyof TService]: GrpcMethodMiddleware<TService, k>[];
+} & {
+	'*'?: DefaultGrpcMiddleware[];
+};

--- a/src/utils/apply-middlewares.ts
+++ b/src/utils/apply-middlewares.ts
@@ -1,0 +1,84 @@
+import {
+	GrpcServiceDefinition,
+	GrpcMethodMiddleware,
+	DefaultGrpcMiddleware,
+} from './../types';
+import { GrpcMiddlewares } from '../types';
+import { CallOptions, Metadata } from '@grpc/grpc-js';
+
+function callMiddlewaresFactory<TService extends GrpcServiceDefinition>(
+	defaultMiddlewares: DefaultGrpcMiddleware[],
+	methodMiddlewares: GrpcMethodMiddleware<TService, keyof TService>[] = [],
+) {
+	if (!methodMiddlewares.length && !defaultMiddlewares.length) {
+		return undefined;
+	}
+
+	return (
+		params: [
+			Parameters<TService[keyof TService]>[0],
+			Metadata,
+			Partial<CallOptions>,
+		],
+	) => {
+		const [, ...others] = params;
+		for (const middleware of defaultMiddlewares) {
+			middleware(others);
+		}
+		params[1] = others[0];
+		params[2] = others[1];
+		for (const middleware of methodMiddlewares) {
+			middleware(params);
+		}
+	};
+}
+
+function getNewParameters<TService extends GrpcServiceDefinition>(
+	args: [
+		Parameters<TService[keyof TService]>[0],
+		Metadata | Partial<CallOptions> | undefined,
+		Partial<CallOptions> | undefined,
+	],
+): [Parameters<TService[keyof TService]>[0], Metadata, Partial<CallOptions>] {
+	const [params] = args;
+	let [, metadata, options] = args;
+	if (!(metadata instanceof Metadata)) {
+		options = metadata ? metadata : {};
+		metadata = new Metadata();
+	} else if (!options) {
+		options = {};
+	}
+	return [params, metadata, options];
+}
+
+export function applyMiddlewares<TService extends GrpcServiceDefinition>(
+	client: TService,
+	serviceMiddlewares?: GrpcMiddlewares<TService>,
+) {
+	if (serviceMiddlewares) {
+		const defaultMiddlewares = serviceMiddlewares['*'] ?? [];
+		for (const k in client) {
+			if (client.hasOwnProperty(k)) {
+				const middlewares = serviceMiddlewares[k];
+				const callMiddlewares = callMiddlewaresFactory(
+					defaultMiddlewares,
+					middlewares,
+				);
+				if (callMiddlewares) {
+					const rawCall = client[k]!;
+					client[k] = ((
+						...args: [
+							Parameters<TService[keyof TService]>[0],
+							Partial<CallOptions> | Metadata | undefined,
+							Partial<CallOptions> | undefined,
+						]
+					) => {
+						const newArgs = getNewParameters<TService>(args);
+						callMiddlewares.call(serviceMiddlewares, newArgs);
+						return (rawCall as Function).apply(client, newArgs);
+					}) as TService[Extract<keyof TService, string>];
+				}
+			}
+		}
+	}
+}

--- a/src/utils/overload-services.ts
+++ b/src/utils/overload-services.ts
@@ -1,30 +1,21 @@
-import { CallOptions, Metadata, ServiceError } from '@grpc/grpc-js';
+import { GrpcServiceClient } from './../types';
+import { ServiceError } from '@grpc/grpc-js';
 import { Status } from '@grpc/grpc-js/build/src/constants';
 import { ServiceClient } from '@grpc/grpc-js/build/src/make-client';
 import { ClientConfig } from '../client-config';
 import { ClientPool } from '../client-pool';
-
-export interface UnaryCall<P> {
-	(param: P, ...args: unknown[]): void;
-}
-export interface UnaryCallPromisify<P, R> {
-	(param: P, deadline: Partial<CallOptions> | undefined): PromiseLike<R>;
-	(
-		param: P,
-		metadata: Metadata,
-		deadline: Partial<CallOptions> | undefined,
-	): PromiseLike<R>;
-}
+import { isStreamCall, RawUnaryCall, UnaryCall } from '../types';
+import { applyMiddlewares } from './apply-middlewares';
 
 export function handlePanic(client: ServiceClient, config: ClientConfig) {
 	ClientPool.renewConnect(config.url, client);
 }
 
 function promisifyUnary<P, R>(
-	unaryCall: UnaryCall<P>,
+	unaryCall: RawUnaryCall<P, R>,
 	client: ServiceClient,
 	config: ClientConfig,
-): UnaryCallPromisify<P, R> {
+): UnaryCall<P, R> {
 	return (param: P, ...args: unknown[]) =>
 		new Promise<R>((resolve, reject) =>
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -44,42 +35,41 @@ function promisifyUnary<P, R>(
 		);
 }
 
-export function overloadServices(
-	client: ServiceClient,
+export function overloadServices<TService extends GrpcServiceClient>(
+	client: TService,
 	config: ClientConfig,
-): ServiceClient {
-	const services = Object.keys(client.__proto__);
-	services.forEach((serviceName) => {
-		const action = client[serviceName] as any;
-		if (!action) {
-			return;
-		}
-		const isUnary = !action?.requestStream && !action?.responseStream;
-		if (isUnary) {
-			(client as any)[serviceName] = promisifyUnary(
-				action.bind(client),
-				client,
-				config,
-			);
-		}
+): TService {
+	for (const serviceName in client.__proto__!) {
+		if (client.__proto__!.hasOwnProperty(serviceName)) {
+			const action = client[serviceName] as any;
+			if (action) {
+				if (isStreamCall(action)) {
+					try {
+						client[serviceName as keyof TService] = ((...args: any) => {
+							const stream = action.apply(client, args);
+							stream.on('error', (error: ServiceError) => {
+								if (error?.code === Status.UNAVAILABLE) {
+									handlePanic(client, config);
+								}
+							});
 
-		if (action?.requestStream || action?.responseStream) {
-			try {
-				client[serviceName] = (...args: any[]) => {
-					const stream = action.apply(client, args);
-					stream.on('error', (error: ServiceError) => {
-						if (error?.code === Status.UNAVAILABLE) {
-							handlePanic(client, config);
-						}
-					});
-
-					return stream;
-				};
-			} catch (error) {
-				console.log(serviceName);
+							return stream;
+						}) as unknown as TService[keyof TService];
+					} catch (error) {
+						console.log(serviceName);
+					}
+				} else {
+					(client as any)[serviceName] = promisifyUnary(
+						action.bind(client),
+						client,
+						config,
+					);
+				}
 			}
 		}
-	});
+	}
+
+	applyMiddlewares(client, config.middlewares);
 
 	return client;
 }

--- a/test/unit/utils/overload-services.spec.ts
+++ b/test/unit/utils/overload-services.spec.ts
@@ -5,6 +5,7 @@ import {
 	overloadServices,
 } from '../../../src/utils/overload-services';
 import * as overload from '../../../src/utils/overload-services';
+import { GrpcServiceClient, UnaryCall } from '../../../src';
 
 class UnaryCallFn extends Function {
 	requeStream: boolean;
@@ -100,9 +101,11 @@ describe(overloadServices.name, () => {
 			__proto__: {
 				test: jest.fn(),
 			},
+		} as unknown as GrpcServiceClient & {
+			test: UnaryCall<string, unknown>;
 		};
 
-		const overService = overload.overloadServices(client as any, config);
+		const overService = overload.overloadServices(client, config);
 		let resultAsync = undefined;
 		let err!: Error;
 		try {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "noImplicitAny": true,
     "alwaysStrict": true,
     "strictBindCallApply": true,
-    "strictFunctionTypes": true
+    "strictFunctionTypes": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["./src", "./test"]
 }


### PR DESCRIPTION
This PR adds the gRPC middleware feature, which gives the ability to add middlewares to be executed just before the real gRPC call.

There are two types of middleware: default and method.
The default middlewares must be declared in the **options.middlewares['*']** property, and it will be executed before every method and before every method middleware. These middlewares receive an array with two parameters: metadata and options. If you want to change the parameters your gRPC method will receive, just changed these array values.
The method middlewares is very similar, but is executed between the default ones and the method call, and receives an array with three values: payload, metadata, and options.

 This feature is being implemented so we can create a utility package in sequence to integrate it with [apm-agent-nodejs](https://github.com/elastic/apm-agent-nodejs) and [open-telemetry/opentelemetry-js](https://github.com/open-telemetry/opentelemetry-js);