### PR TITLE
feat: adding noPanicControl option

### DIFF
--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -12,4 +12,5 @@ export interface ClientConfig<TService extends GrpcServiceDefinition = any> {
 	PackageOptions?: PackageOptions;
 	grpcOptions?: Partial<ChannelOptions>;
 	middlewares?: GrpcMiddlewares<TService>;
+	noPanicControl?: boolean;
 }

--- a/src/utils/overload-services.ts
+++ b/src/utils/overload-services.ts
@@ -8,7 +8,9 @@ import { isStreamCall, RawUnaryCall, UnaryCall } from '../types';
 import { applyMiddlewares } from './apply-middlewares';
 
 export function handlePanic(client: ServiceClient, config: ClientConfig) {
-	ClientPool.renewConnect(config.url, client);
+	if (config.noPanicControl !== true && config.maxConnections) {
+		ClientPool.renewConnect(config.url, client);
+	}
 }
 
 function promisifyUnary<P, R>(

--- a/test/unit/utils/overload-services.spec.ts
+++ b/test/unit/utils/overload-services.spec.ts
@@ -121,21 +121,14 @@ describe(overloadServices.name, () => {
 		);
 	});
 
-	it('Should not trigger Panic when noPanicControl is true', async () => {
-		jest.spyOn(overload, 'handlePanic').mockImplementation(() => {
-			return 'handlePanic';
-		});
-
-		const config = {
+	describe('disabled panic', () => {
+		const configBase = {
 			namespace: 'abc.def',
 			protoFile: 'health-check.proto',
 			url: 'test.service2',
-			maxConnections: 3,
 			service: 'Health',
 			secure: true,
-			noPanicControl: true,
 		};
-
 		const client = {
 			test: new UnaryCallFnFail(),
 			url: 'test.service2',
@@ -147,56 +140,53 @@ describe(overloadServices.name, () => {
 			test: UnaryCall<string, unknown>;
 		};
 
-		const overService = overload.overloadServices(client, config);
-		let resultAsync = undefined;
-		let err!: Error;
-		try {
-			resultAsync = await overService.test('any');
-		} catch (error) {
-			err = error as Error;
-		}
+		it('Should not trigger Panic when noPanicControl is true', async () => {
+			jest.spyOn(overload, 'handlePanic').mockImplementation(() => {
+				return 'handlePanic';
+			});
 
-		expect(handlePanic).toHaveCallsLike();
-		expect(resultAsync).toBe(undefined);
-		expect(err.message).toBe('Fake error');
-	});
+			const config = {
+				...configBase,
+				maxConnections: 3,
+				noPanicControl: true,
+			};
 
-	it('Should not trigger Panic when maxConnections is 0', async () => {
-		jest.spyOn(overload, 'handlePanic').mockImplementation(() => {
-			return 'handlePanic';
+			const overService = overload.overloadServices(client, config);
+			let resultAsync = undefined;
+			let err!: Error;
+			try {
+				resultAsync = await overService.test('any');
+			} catch (error) {
+				err = error as Error;
+			}
+
+			expect(handlePanic).toHaveCallsLike();
+			expect(resultAsync).toBe(undefined);
+			expect(err.message).toBe('Fake error');
 		});
 
-		const config = {
-			namespace: 'abc.def',
-			protoFile: 'health-check.proto',
-			url: 'test.service2',
-			maxConnections: 0,
-			service: 'Health',
-			secure: true,
-		};
+		it('Should not trigger Panic when maxConnections is 0', async () => {
+			jest.spyOn(overload, 'handlePanic').mockImplementation(() => {
+				return 'handlePanic';
+			});
 
-		const client = {
-			test: new UnaryCallFnFail(),
-			url: 'test.service2',
-			close: jest.fn(),
-			__proto__: {
-				test: jest.fn(),
-			},
-		} as unknown as GrpcServiceClient & {
-			test: UnaryCall<string, unknown>;
-		};
+			const config = {
+				...configBase,
+				maxConnections: 0,
+			};
 
-		const overService = overload.overloadServices(client, config);
-		let resultAsync = undefined;
-		let err!: Error;
-		try {
-			resultAsync = await overService.test('any');
-		} catch (error) {
-			err = error as Error;
-		}
+			const overService = overload.overloadServices(client, config);
+			let resultAsync = undefined;
+			let err!: Error;
+			try {
+				resultAsync = await overService.test('any');
+			} catch (error) {
+				err = error as Error;
+			}
 
-		expect(handlePanic).toHaveCallsLike();
-		expect(resultAsync).toBe(undefined);
-		expect(err.message).toBe('Fake error');
+			expect(handlePanic).toHaveCallsLike();
+			expect(resultAsync).toBe(undefined);
+			expect(err.message).toBe('Fake error');
+		});
 	});
 });

--- a/test/unit/utils/overload-services.spec.ts
+++ b/test/unit/utils/overload-services.spec.ts
@@ -120,4 +120,83 @@ describe(overloadServices.name, () => {
 			'Not found pool test.service2 to renew connection',
 		);
 	});
+
+	it('Should not trigger Panic when noPanicControl is true', async () => {
+		jest.spyOn(overload, 'handlePanic').mockImplementation(() => {
+			return 'handlePanic';
+		});
+
+		const config = {
+			namespace: 'abc.def',
+			protoFile: 'health-check.proto',
+			url: 'test.service2',
+			maxConnections: 3,
+			service: 'Health',
+			secure: true,
+			noPanicControl: true,
+		};
+
+		const client = {
+			test: new UnaryCallFnFail(),
+			url: 'test.service2',
+			close: jest.fn(),
+			__proto__: {
+				test: jest.fn(),
+			},
+		} as unknown as GrpcServiceClient & {
+			test: UnaryCall<string, unknown>;
+		};
+
+		const overService = overload.overloadServices(client, config);
+		let resultAsync = undefined;
+		let err!: Error;
+		try {
+			resultAsync = await overService.test('any');
+		} catch (error) {
+			err = error as Error;
+		}
+
+		expect(handlePanic).toHaveCallsLike();
+		expect(resultAsync).toBe(undefined);
+		expect(err.message).toBe('Fake error');
+	});
+
+	it('Should not trigger Panic when maxConnections is 0', async () => {
+		jest.spyOn(overload, 'handlePanic').mockImplementation(() => {
+			return 'handlePanic';
+		});
+
+		const config = {
+			namespace: 'abc.def',
+			protoFile: 'health-check.proto',
+			url: 'test.service2',
+			maxConnections: 0,
+			service: 'Health',
+			secure: true,
+		};
+
+		const client = {
+			test: new UnaryCallFnFail(),
+			url: 'test.service2',
+			close: jest.fn(),
+			__proto__: {
+				test: jest.fn(),
+			},
+		} as unknown as GrpcServiceClient & {
+			test: UnaryCall<string, unknown>;
+		};
+
+		const overService = overload.overloadServices(client, config);
+		let resultAsync = undefined;
+		let err!: Error;
+		try {
+			resultAsync = await overService.test('any');
+		} catch (error) {
+			err = error as Error;
+		}
+
+		expect(handlePanic).toHaveCallsLike();
+		expect(resultAsync).toBe(undefined);
+		expect(err.message).toBe('Fake error');
+	});
 });


### PR DESCRIPTION
This PR adds a new option: noPanicControl. If you don't want to have panic control, just pass it as true.
Also I treated a bug: if maxConnections is 0, panic should not be handled, as it only makes sense for a connection pool.